### PR TITLE
Relax version constraints on text and scotty

### DIFF
--- a/kansas-comet.cabal
+++ b/kansas-comet.cabal
@@ -27,10 +27,10 @@ Library
                        aeson            == 0.7.*,
                        containers       == 0.5.*,
                        data-default     == 0.5.*,
-                       scotty           >= 0.7.2        && <= 0.7.2,
+                       scotty           >= 0.7.2        && < 0.8,
                        stm              >= 2.2          && <= 2.4.3,
                        transformers     == 0.3.*,
-                       text             == 1.1.*,
+                       text             >= 0.11.3.1 && < 1.2,
                        time             == 1.4.*
 
 -- text is needed just for scotty's literal


### PR DESCRIPTION
When I tried to install the sunroof packages with newer packages I ran into a few version conflicts. This should make komet a bit more flexible and it seems to work well.

It would be nice if a new version is released soon, since I'd like to reference it the updates of the sunroof packages:
- b31f8917ca69e70362bd0989e630f81f7f80ca91 - Here is where we reference the new version
- b0c588c71d5472a9834c3f13aaa07121e2e23084
- 08267355583dc1c4a676f5007bba0442720546ec

These fixes were necessary because of ku-fpg/sunroof-examples#1
