### PR TITLE
Relaxed unordered-containers upper bounds

### DIFF
--- a/kansas-comet.cabal
+++ b/kansas-comet.cabal
@@ -22,16 +22,16 @@ Library
   Exposed-modules:     Web.Scotty.Comet
   other-modules:       Paths_kansas_comet
   default-language:    Haskell2010
-  build-depends:       base             >= 4.6          && < 4.8,
-                       unordered-containers >= 0.2.3    && <= 0.2.4.0,
-                       aeson            == 0.7.*,
+  build-depends:       aeson            == 0.7.*,
+                       base             >= 4.6       && < 4.8,
                        containers       == 0.5.*,
                        data-default     == 0.5.*,
                        scotty           == 0.8.*,
-                       stm              >= 2.2		&& < 2.5,
-                       transformers     >= 0.3          && < 0.5,
-                       text             >= 1.1		&& < 1.2,
-                       time             == 1.4.*
+                       stm              >= 2.2       && < 2.5,
+                       text             >= 1.1       && < 1.2,
+                       time             == 1.4.*,
+                       transformers     >= 0.3       && < 0.5,
+                       unordered-containers >= 0.2.3 && < 0.2.6
 
   GHC-options: -Wall -fno-warn-orphans
 


### PR DESCRIPTION
Now that [`unordered-containers`](https://github.com/tibbe/unordered-containers) is at version 0.2.5.0, I bumped the upper bound to < 0.2.6. Everything still compiles without warnings.
