### PR TITLE
Bumped up scotty version bounds

### DIFF
--- a/kansas-comet.cabal
+++ b/kansas-comet.cabal
@@ -26,7 +26,7 @@ Library
                        base                 >= 4.6   && < 4.8,
                        containers           == 0.5.*,
                        data-default         == 0.5.*,
-                       scotty               == 0.8.*,
+                       scotty               >= 0.8   && < 0.10,
                        stm                  >= 2.2   && < 2.5,
                        text                 >= 1.1   && < 1.2,
                        time                 == 1.4.*,


### PR DESCRIPTION
Allow `kansas-comet` to use `scotty-0.9.0`.
