### PR TITLE
Adding websockets to kansas-comet

### DIFF
--- a/Web/Scotty/Comet.hs
+++ b/Web/Scotty/Comet.hs
@@ -10,6 +10,7 @@ module Web.Scotty.Comet
     , debugDocument
     , debugReplyDocument
     , defaultOptions
+    , socketApplication
     ) where
 
 import Web.Scotty (ScottyM, text, post, capture, param, setHeader, get, ActionM, jsonData)
@@ -30,6 +31,30 @@ import qualified Data.Text      as T
 import Data.Time.Calendar
 import Data.Time.Clock
 import Numeric
+import qualified Network.WebSockets as WS
+
+-- Opening web-socket connection and handling calling the call-back function
+-- Adding websocket connection to Docuement object
+
+socketApplication :: (Document -> IO ()) -> WS.PendingConnection -> IO ()
+socketApplication callback pending = do
+    conn <- WS.acceptRequest pending
+    evnt::T.Text <- WS.receiveData conn
+    picture <- atomically $ newEmptyTMVar
+    callbacks <- atomically $ newTVar $ Map.empty
+    queue <- atomically $ newTChan
+    let cxt = Document picture callbacks queue 0 (Just conn)
+    callback cxt
+    receiveEvents conn cxt
+
+-- Continuously listening to incoming socket connection
+
+receiveEvents :: WS.Connection -> Document -> IO()
+receiveEvents conn document = forever $ do
+    evnt <- WS.receiveData conn
+    let val = fromJust $ decode' evnt
+    liftIO $ atomically $ do
+                          writeTChan (eventQueue document) val
 
 -- | connect "/foobar" (...) gives a scotty session that:
 --
@@ -44,9 +69,9 @@ connect opt callback = do
    if not rtsSupportsBoundThreads  -- we need the -threaded flag turned on
    then liftIO $ do putStrLn "Application needs to be re-compiled with -threaded flag"
                     exitFailure
-   else return ()                 
-                  
-          
+   else return ()
+
+
    when (verbose opt >= 1) $ liftIO $ putStrLn $ "kansas-comet connect with prefix=" ++ show (prefix opt)
 
    -- A unique number generator, or ephemeral generator.
@@ -74,7 +99,7 @@ connect opt callback = do
             picture <- atomically $ newEmptyTMVar
             callbacks <- atomically $ newTVar $ Map.empty
             queue <- atomically $ newTChan
-            let cxt = Document picture callbacks queue uq
+            let cxt = Document picture callbacks queue uq Nothing
             liftIO $ atomically $ do
                     db <- readTVar contextDB
                     -- assumes the getUniq is actually unique
@@ -162,7 +187,7 @@ connect opt callback = do
            num <- param "id"
 
            when (verbose opt >= 2) $ liftIO $ putStrLn $
-                "Kansas Comet: post .../event/" ++ show num 
+                "Kansas Comet: post .../event/" ++ show num
 
            wrappedVal :: Value <- jsonData
            -- Unwrap the data wrapped, because 'jsonData' only supports
@@ -180,7 +205,7 @@ connect opt callback = do
                    liftIO $ atomically $ do
                            writeTChan (eventQueue doc) val
                    text $ LT.pack ""
-           
+
    return ()
 
 -- | 'kCometPlugin' provides the location of the Kansas Comet jQuery plugin.
@@ -190,12 +215,17 @@ kCometPlugin = do
         return $ dataDir ++ "/static/js/kansas-comet.js"
 
 -- | 'send' sends a javascript fragement to a document.
+-- Checks for socket connection if present uses socket connection to send the document.
 -- The Text argument will be evaluated before sending (in case there is an error,
 -- or some costly evaluation needs done first).
 -- 'send' suspends the thread if the last javascript has not been *dispatched*
 -- the the browser.
 send :: Document -> T.Text -> IO ()
-send doc js = atomically $ putTMVar (sending doc) $! js
+send doc js =
+  case (socketConnection doc) of
+    Just connection -> WS.sendTextData connection $ js
+    Nothing -> atomically $ putTMVar (sending doc) $! js
+
 
 -- | wait for a virtual-to-this-document's port numbers' reply.
 getReply :: Document -> Int -> IO Value
@@ -210,12 +240,13 @@ getReply doc num = do
 
 -- | 'Document' is the Handle into a specific interaction with a web page.
 data Document = Document
-        { sending    :: TMVar T.Text             -- ^ Code to be sent to the browser
-                                                 -- This is a TMVar to stop the generation
-                                                 -- getting ahead of the rendering engine
-        , replies    :: TVar (Map.Map Int Value) -- ^ This is numbered replies, to ports
-        , eventQueue :: TChan Value              -- ^ Events being sent
-        , _secret    :: Int                      -- ^ the (session) number of this document
+        { sending          :: TMVar T.Text             -- ^ Code to be sent to the browser
+                                                       -- This is a TMVar to stop the generation
+                                                       -- getting ahead of the rendering engine
+        , replies          :: TVar (Map.Map Int Value) -- ^ This is numbered replies, to ports
+        , eventQueue       :: TChan Value              -- ^ Events being sent
+        , _secret          :: Int                      -- ^ the (session) number of this document
+        , socketConnection :: Maybe (WS.Connection)    -- Socket connection if cleint is using websocket
         }
 
 -- 'Options' for Comet.
@@ -246,11 +277,10 @@ debugDocument = do
           res <- atomically $ takeTMVar $ picture
           putStrLn $ "Sending: " ++ show res
   q <- atomically $ newTChan
-  return $ Document picture callbacks q 0
+  return $ Document picture callbacks q 0 Nothing
 
 -- | Fake a specific reply on a virtual @Document@ port.
 debugReplyDocument :: Document -> Int -> Value -> IO ()
 debugReplyDocument doc uq val = atomically $ do
    m <- readTVar (replies doc)
    writeTVar (replies doc) $ Map.insert uq val m
-

--- a/kansas-comet.cabal
+++ b/kansas-comet.cabal
@@ -31,7 +31,8 @@ Library
                        text                 >= 1.1   && < 1.3,
                        time                 >= 1.4   && < 1.6,
                        transformers         >= 0.3   && < 0.5,
-                       unordered-containers >= 0.2.3 && < 0.2.6
+                       unordered-containers >= 0.2.3 && < 0.2.6,
+                       websockets            == 0.8.*
 
   GHC-options: -Wall -fno-warn-orphans
 


### PR DESCRIPTION
- Added websockets to kansas-comet
- Added socketConnection object to Document
- socketApplication method to complete handshake from client browser
- receiveEvents to will handle socket connection which is open between client and server 
- kansas-comet.js to initiate a websocket connection if browser is capable of establishing websocket else fall     back on long polling method
- Some formatting changes to kansas-comet.js
- Added additional libraries to cabal
- Dr. @andygill please review :) 
- Will change example once this is merges by updating cabal version
